### PR TITLE
Fix installation failure

### DIFF
--- a/webroot/js/web_installer/installation.js
+++ b/webroot/js/web_installer/installation.js
@@ -48,7 +48,7 @@ $(function () {
     {
         rollStatus();
         const installUrl = `${baseUrl}install/installation/do_install.json`;
-        const response = await fetch(installUrl);
+        const response = await fetch(installUrl, {credentials: "include"});
         clearTimeout(rollStatusTimeout);
         const json = await response.json();
         if (response.ok) {


### PR DESCRIPTION
do_install is called with fetch() which doesn't include cookies by default. The server can't correlate the request with the session and tries to start over. This includes the cookie and allows installation to proceed.

This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature